### PR TITLE
added Chinese length distance units (lel)

### DIFF
--- a/lib/unit.dart
+++ b/lib/unit.dart
@@ -10,7 +10,12 @@ enum DistanceUnit {
   FEET,
   INCHES,
   YARD,
-  MICROMETRES
+  MICROMETRES,
+  CHINESE_CUN,
+  CHINESE_CHI,
+  CHINESE_ZHANG,
+  CHINESE_LI
+
 }
 
 class DistanceConversion {
@@ -25,7 +30,11 @@ class DistanceConversion {
     DistanceUnit.FEET: 3.28084,
     DistanceUnit.YARD: 1.09361,
     DistanceUnit.INCHES: 39.3701,
-    DistanceUnit.MILES: 0.000621371
+    DistanceUnit.MILES: 0.000621371,
+    DistanceUnit.CHINESE_CUN: 30,
+    DistanceUnit.CHINESE_CHI: 3,
+    DistanceUnit.CHINESE_ZHANG: 3 / 10,
+    DistanceUnit.CHINESE_LI: 1 / 500
   };
 
   static Map<Tuple2<DistanceUnit, DistanceUnit>, Function>

--- a/test/unit_test.dart
+++ b/test/unit_test.dart
@@ -12,11 +12,20 @@ main() {
       expect(0.001, centiToKm(100));
     });
 
-    test('kilometres to centimetres', () {
+    test('kilometres to yards', () {
       expect(
           1465.4374,
           DistanceConversion.convertValue(
               DistanceUnit.KILOMETRES, DistanceUnit.YARD, 1.34));
     });
+
+    // 一市里是半公里
+    test('li to kilometres', () {
+      expect(
+          4094.3975,
+          DistanceConversion.convertValue(
+              DistanceUnit.CHINESE_LI, DistanceUnit.KILOMETRES, 8188.7950));
+    });
+
   });
 }


### PR DESCRIPTION
added common Chinese lenght units effectve in 1930.
Units from: "The Weights and Measures Act (1929)", Legislative Yuan
https://en.wikipedia.org/wiki/Chinese_units_of_measurement#cite_note-ROC1930-3

hi joel